### PR TITLE
Fix JSON mode exponent

### DIFF
--- a/ffc.h
+++ b/ffc.h
@@ -1271,13 +1271,16 @@ ffc_parsed ffc_parse_number_string(
       ++p;
     }
     if ((p == pend) || !ffc_is_integer(*p)) {
-      if (!(uint64_t)(fmt & FFC_FORMAT_FLAG_FIXED)) {
+      if (basic_json_fmt || !(uint64_t)(fmt & FFC_FORMAT_FLAG_FIXED)) {
         // The exponential part is invalid for scientific notation, so it must
         // be a trailing token for fixed notation. However, fixed notation is
-        // disabled, so report a scientific notation error.
+        // disabled, so report a scientific notation error. JSON mode is strict
+        // for the scientific form (exp = e [ minus / plus ] 1*DIGIT in RFC
+        // 8259) so we also report the error, even though FIXED is part of
+        // FFC_PRESET_JSON.
         return ffc_report_parse_error(p, FFC_PARSE_OUTCOME_MISSING_EXPONENTIAL_PART);
       }
-      // Otherwise, we will be ignoring the 'e'.
+      // Otherwise (fixed-tolerant, non-JSON), we will be ignoring the 'e'.
       p = location_of_e;
     } else {
       while ((p != pend) && ffc_is_integer(*p)) {

--- a/src/parse.h
+++ b/src/parse.h
@@ -346,13 +346,16 @@ ffc_parsed ffc_parse_number_string(
       ++p;
     }
     if ((p == pend) || !ffc_is_integer(*p)) {
-      if (!(uint64_t)(fmt & FFC_FORMAT_FLAG_FIXED)) {
+      if (basic_json_fmt || !(uint64_t)(fmt & FFC_FORMAT_FLAG_FIXED)) {
         // The exponential part is invalid for scientific notation, so it must
         // be a trailing token for fixed notation. However, fixed notation is
-        // disabled, so report a scientific notation error.
+        // disabled, so report a scientific notation error. JSON mode is strict
+        // for the scientific form (exp = e [ minus / plus ] 1*DIGIT in RFC
+        // 8259) so we also report the error, even though FIXED is part of
+        // FFC_PRESET_JSON.
         return ffc_report_parse_error(p, FFC_PARSE_OUTCOME_MISSING_EXPONENTIAL_PART);
       }
-      // Otherwise, we will be ignoring the 'e'.
+      // Otherwise (fixed-tolerant, non-JSON), we will be ignoring the 'e'.
       p = location_of_e;
     } else {
       while ((p != pend) && ffc_is_integer(*p)) {

--- a/test_src/test.c
+++ b/test_src/test.c
@@ -492,6 +492,62 @@ void float_special(void) {
   verify_float("1.1754943508e-45f", 1.1754943508e-45f);
 }
 
+void double_json_mode(void) {
+  struct test_case {
+    char *input;
+    ffc_outcome expected_outcome;
+    double expected_value;
+  };
+
+  // valid stuff
+  const struct test_case ok_cases[] = {
+    {"0",       FFC_OUTCOME_OK, 0.0},
+    {"-0",      FFC_OUTCOME_OK, 0.0},
+    {"1",       FFC_OUTCOME_OK, 1.0},
+    {"-1",      FFC_OUTCOME_OK, -1.0},
+    {"123",     FFC_OUTCOME_OK, 123.0},
+    {"1.5",     FFC_OUTCOME_OK, 1.5},
+    {"-1.5",    FFC_OUTCOME_OK, -1.5},
+    {"0.5",     FFC_OUTCOME_OK, 0.5},
+    {"1e3",     FFC_OUTCOME_OK, 1000.0},
+    {"1E3",     FFC_OUTCOME_OK, 1000.0},
+    {"1e+3",    FFC_OUTCOME_OK, 1000.0},
+    {"1e-3",    FFC_OUTCOME_OK, 0.001},
+    {"1.5e2",   FFC_OUTCOME_OK, 150.0},
+    {"-1.5e-2", FFC_OUTCOME_OK, -0.015},
+  };
+
+  // invalid stuff
+  const char * const invalid_cases[] = {
+    "",
+    "-",
+    ".5",
+    "1.",
+    "1e",
+    "1E",
+    "1e+",
+    "1e-",
+    "1.5e",
+    "01",
+    "00",
+    "-01",
+    "+1",
+  };
+
+  ffc_parse_options json_opts = ffc_parse_options_default();
+  json_opts.format = FFC_PRESET_JSON;
+
+  for (size_t i = 0; i < sizeof(ok_cases)/sizeof(*ok_cases); i++) {
+    const struct test_case *t = &ok_cases[i];
+    verify_double_ext(strlen(t->input), t->input, t->expected_value,
+                      t->expected_outcome, json_opts);
+  }
+  for (size_t i = 0; i < sizeof(invalid_cases)/sizeof(*invalid_cases); i++) {
+    verify_double_ext(strlen(invalid_cases[i]), invalid_cases[i], 0.0,
+                      FFC_OUTCOME_INVALID_INPUT, json_opts);
+  }
+}
+
 int main(void) {
   // verify_float("1.1754942807573642917e-38", 0x1.fffffcp-127f);
   // exit(0);
@@ -517,6 +573,7 @@ int main(void) {
   double_rounds_to_nearest();
   double_parse_zero();
   double_parse_negative_zero();
+  double_json_mode();
 
   float_special();
 


### PR DESCRIPTION
Per RFC 8259 `e`|`E` has to be followed by digits, however before this patch `1e` and `1e+` with `FFC_PRESET_JSON` would be accepted as a "fixed-point" number with a trailing `e` | `E`.