### PR TITLE
Add ffc_parse_json_number API

### DIFF
--- a/ffc.h
+++ b/ffc.h
@@ -253,6 +253,32 @@ uint64_t ffc_parse_u64_simple(size_t len, const char *input, int base, ffc_outco
 int32_t  ffc_parse_i32_simple(size_t len, const char *input, int base, ffc_outcome *outcome);
 uint32_t ffc_parse_u32_simple(size_t len, const char *input, int base, ffc_outcome *outcome);
 
+/**
+ * Parse a JSON number from the range [start, end) and return an int64_t or a double
+ *
+ * If the outcome is FCC_OUTCOME_OK
+ *  If kind == FFC_JSON_NUM_KIND_INT64, value will be an int64
+ *  If kind == FCC_JSON_NUM_DOUBLE, value will be a double
+ *
+ * The returned ffc_result's ptr points at the byte where parsing stopped
+ */
+
+typedef uint32_t ffc_json_number_kind;
+enum ffc_json_number_kind_bits {
+  FFC_JSON_NUM_KIND_INT64  = 0,
+  FFC_JSON_NUM_KIND_DOUBLE = 1,
+};
+
+typedef struct ffc_json_number {
+  ffc_json_number_kind kind;
+  union {
+    int64_t i64;
+    double  f64;
+  } value;
+} ffc_json_number;
+
+ffc_result ffc_parse_json_number(const char *start, const char *end, ffc_json_number *out);
+
 #endif // FFC_API
 
 #ifdef FFC_IMPL
@@ -3203,7 +3229,56 @@ uint32_t ffc_parse_u32_simple(size_t len, const char *input, int base, ffc_outco
   return out;
 }
 
-#undef FFC_DOUBLE_SMALLEST_POWER_OF_10        
+ffc_result ffc_parse_json_number(const char *start, const char *end,
+                                 ffc_json_number *out) {
+  ffc_result answer;
+
+  if (start == end) {
+    answer.ptr = (char *)start;
+    answer.outcome = FFC_OUTCOME_INVALID_INPUT;
+    return answer;
+  }
+
+  ffc_parse_options opts;
+  opts.format = FFC_PRESET_JSON;
+  opts.decimal_point = '.';
+
+  ffc_parsed pns = ffc_parse_number_string(start, end, opts, true);
+
+  if (!pns.valid) {
+    answer.ptr = (char *)pns.lastmatch;
+    answer.outcome = FFC_OUTCOME_INVALID_INPUT;
+    return answer;
+  }
+
+  // INT64 or DOUBLE?
+  // For an integer bytes consumed past the sign should be just digits
+  // If we see '.' then `fractional_part_start` is not NULL
+  // If we see e/E then consumed span is > int_part_len (e + $digit)
+  // If both above are true then we have a DOUBLE
+  size_t consumed = (size_t)(pns.lastmatch - start) - (pns.negative ? 1 : 0);
+  bool is_integer = (pns.fraction_part_start == NULL) && (consumed == pns.int_part_len);
+
+  ffc_result r;
+  if (is_integer) {
+    ffc_int_value v = {0};
+    r = ffc_parse_int_string(start, end, &v, FFC_INT_KIND_S64, opts, 10);
+    out->kind = FFC_JSON_NUM_KIND_INT64;
+    if (r.outcome == FFC_OUTCOME_OK) {
+      out->value.i64 = v.s64;
+    }
+  } else {
+    ffc_value v = {0};
+    r = ffc_from_chars_advanced(pns, &v, FFC_VALUE_KIND_DOUBLE);
+    out->kind = FFC_JSON_NUM_KIND_DOUBLE;
+    if (r.outcome == FFC_OUTCOME_OK) {
+      out->value.f64 = v.d;
+    }
+  }
+  return r;
+}
+
+#undef FFC_DOUBLE_SMALLEST_POWER_OF_10
 #undef FFC_DOUBLE_LARGEST_POWER_OF_10         
 #undef FFC_DOUBLE_SIGN_INDEX                  
 #undef FFC_DOUBLE_INFINITE_POWER              

--- a/src/api.h
+++ b/src/api.h
@@ -141,4 +141,30 @@ uint64_t ffc_parse_u64_simple(size_t len, const char *input, int base, ffc_outco
 int32_t  ffc_parse_i32_simple(size_t len, const char *input, int base, ffc_outcome *outcome);
 uint32_t ffc_parse_u32_simple(size_t len, const char *input, int base, ffc_outcome *outcome);
 
+/**
+ * Parse a JSON number from the range [start, end) and return an int64_t or a double
+ *
+ * If the outcome is FCC_OUTCOME_OK
+ *  If kind == FFC_JSON_NUM_KIND_INT64, value will be an int64
+ *  If kind == FCC_JSON_NUM_DOUBLE, value will be a double
+ *
+ * The returned ffc_result's ptr points at the byte where parsing stopped
+ */
+
+typedef uint32_t ffc_json_number_kind;
+enum ffc_json_number_kind_bits {
+  FFC_JSON_NUM_KIND_INT64  = 0,
+  FFC_JSON_NUM_KIND_DOUBLE = 1,
+};
+
+typedef struct ffc_json_number {
+  ffc_json_number_kind kind;
+  union {
+    int64_t i64;
+    double  f64;
+  } value;
+} ffc_json_number;
+
+ffc_result ffc_parse_json_number(const char *start, const char *end, ffc_json_number *out);
+
 #endif // FFC_API

--- a/src/ffc.h
+++ b/src/ffc.h
@@ -479,7 +479,56 @@ uint32_t ffc_parse_u32_simple(size_t len, const char *input, int base, ffc_outco
   return out;
 }
 
-#undef FFC_DOUBLE_SMALLEST_POWER_OF_10        
+ffc_result ffc_parse_json_number(const char *start, const char *end,
+                                 ffc_json_number *out) {
+  ffc_result answer;
+
+  if (start == end) {
+    answer.ptr = (char *)start;
+    answer.outcome = FFC_OUTCOME_INVALID_INPUT;
+    return answer;
+  }
+
+  ffc_parse_options opts;
+  opts.format = FFC_PRESET_JSON;
+  opts.decimal_point = '.';
+
+  ffc_parsed pns = ffc_parse_number_string(start, end, opts, true);
+
+  if (!pns.valid) {
+    answer.ptr = (char *)pns.lastmatch;
+    answer.outcome = FFC_OUTCOME_INVALID_INPUT;
+    return answer;
+  }
+
+  // INT64 or DOUBLE?
+  // For an integer bytes consumed past the sign should be just digits
+  // If we see '.' then `fractional_part_start` is not NULL
+  // If we see e/E then consumed span is > int_part_len (e + $digit)
+  // If both above are true then we have a DOUBLE
+  size_t consumed = (size_t)(pns.lastmatch - start) - (pns.negative ? 1 : 0);
+  bool is_integer = (pns.fraction_part_start == NULL) && (consumed == pns.int_part_len);
+
+  ffc_result r;
+  if (is_integer) {
+    ffc_int_value v = {0};
+    r = ffc_parse_int_string(start, end, &v, FFC_INT_KIND_S64, opts, 10);
+    out->kind = FFC_JSON_NUM_KIND_INT64;
+    if (r.outcome == FFC_OUTCOME_OK) {
+      out->value.i64 = v.s64;
+    }
+  } else {
+    ffc_value v = {0};
+    r = ffc_from_chars_advanced(pns, &v, FFC_VALUE_KIND_DOUBLE);
+    out->kind = FFC_JSON_NUM_KIND_DOUBLE;
+    if (r.outcome == FFC_OUTCOME_OK) {
+      out->value.f64 = v.d;
+    }
+  }
+  return r;
+}
+
+#undef FFC_DOUBLE_SMALLEST_POWER_OF_10
 #undef FFC_DOUBLE_LARGEST_POWER_OF_10         
 #undef FFC_DOUBLE_SIGN_INDEX                  
 #undef FFC_DOUBLE_INFINITE_POWER              

--- a/test_src/test.c
+++ b/test_src/test.c
@@ -548,6 +548,149 @@ void double_json_mode(void) {
   }
 }
 
+void json_number_unified(void) {
+  // valid ints
+  struct int_case { const char *input; int64_t expected; };
+  const struct int_case int_ok[] = {
+    {"0",                    0},
+    {"-0",                   0},
+    {"1",                    1},
+    {"-1",                  -1},
+    {"123",                123},
+    {"12345678901234567",  12345678901234567LL},
+    {"-9223372036854775808", INT64_MIN},
+    {"9223372036854775807",  INT64_MAX},
+  };
+  for (size_t i = 0; i < sizeof(int_ok)/sizeof(*int_ok); i++) {
+    ffc_json_number nr = {0};
+    ffc_result r = ffc_parse_json_number(
+        int_ok[i].input,
+        int_ok[i].input + strlen(int_ok[i].input),
+        &nr
+    );
+    if (r.outcome != FFC_OUTCOME_OK) {
+      printf("\nFAIL json_number_unified \"%s\": outcome %s (expected ok)\n",
+             int_ok[i].input, get_outcome_name(r.outcome));
+      FAILS += 1;
+      continue;
+    }
+    if (nr.kind != FFC_JSON_NUM_KIND_INT64) {
+      printf("\nFAIL json_number_unified \"%s\": expected kind INT64, got DOUBLE\n",
+             int_ok[i].input);
+      FAILS += 1;
+      continue;
+    }
+    if (nr.value.i64 != int_ok[i].expected) {
+      printf("\nFAIL json_number_unified \"%s\": expected %lld, got %lld\n",
+             int_ok[i].input, (long long)int_ok[i].expected, (long long)nr.value.i64);
+      FAILS += 1;
+    }
+  }
+
+  // valid doubles
+  struct float_case { const char *input; double expected; };
+  const struct float_case double_ok[] = {
+    {"1.0",      1.0},
+    {"-1.5",    -1.5},
+    {"0.5",      0.5},
+    {"1e0",      1.0},
+    {"1E0",      1.0},
+    {"1e3",   1000.0},
+    {"1e+3",  1000.0},
+    {"1e-3",     0.001},
+    {"1.5e2",  150.0},
+    {"-1.5e-2", -0.015},
+  };
+  for (size_t i = 0; i < sizeof(double_ok)/sizeof(*double_ok); i++) {
+    ffc_json_number nr = {0};
+    ffc_result r = ffc_parse_json_number(
+        double_ok[i].input,
+        double_ok[i].input + strlen(double_ok[i].input),
+        &nr
+    );
+    if (r.outcome != FFC_OUTCOME_OK) {
+      printf("\nFAIL json_number_unified \"%s\": outcome %s (expected ok)\n",
+             double_ok[i].input, get_outcome_name(r.outcome));
+      FAILS += 1;
+      continue;
+    }
+    if (nr.kind != FFC_JSON_NUM_KIND_DOUBLE) {
+      printf("\nFAIL json_number_unified \"%s\": expected kind DOUBLE, got INT64\n",
+             double_ok[i].input);
+      FAILS += 1;
+      continue;
+    }
+    if (nr.value.f64 != double_ok[i].expected) {
+      printf("\nFAIL json_number_unified \"%s\": expected %g, got %g\n",
+             double_ok[i].input, double_ok[i].expected, nr.value.f64);
+      FAILS += 1;
+    }
+  }
+
+  // out of range outcomes with large int and double
+  {
+    const char *input = "99999999999999999999999999";
+    ffc_json_number nr = {0};
+    ffc_result r = ffc_parse_json_number(input, input + strlen(input), &nr);
+    if (r.outcome != FFC_OUTCOME_OUT_OF_RANGE || nr.kind != FFC_JSON_NUM_KIND_INT64) {
+      printf("\nFAIL json_number_unified big int \"%s\": outcome=%s kind=%d\n",
+             input, get_outcome_name(r.outcome), (int)nr.kind);
+      FAILS += 1;
+    }
+  }
+  {
+    const char *input = "1e400";
+    ffc_json_number nr = {0};
+    ffc_result r = ffc_parse_json_number(input, input + strlen(input), &nr);
+    if (r.outcome != FFC_OUTCOME_OUT_OF_RANGE || nr.kind != FFC_JSON_NUM_KIND_DOUBLE) {
+      printf("\nFAIL json_number_unified big double \"%s\": outcome=%s kind=%d\n",
+             input, get_outcome_name(r.outcome), (int)nr.kind);
+      FAILS += 1;
+    }
+  }
+
+  // json number invalid stuff
+  const char * const invalid[] = {
+    "",
+    "-",
+    ".5",
+    "1.",
+    "01",
+    "1e",
+    "1E",
+    "0.1e",
+    "0.1E",
+    "+1",
+  };
+  for (size_t i = 0; i < sizeof(invalid)/sizeof(*invalid); i++) {
+    ffc_json_number nr = {0};
+    ffc_result r = ffc_parse_json_number(
+        invalid[i],
+        invalid[i] + strlen(invalid[i]),
+        &nr
+    );
+    if (r.outcome != FFC_OUTCOME_INVALID_INPUT) {
+      printf("\nFAIL json_number_unified invalid \"%s\": outcome %s (expected invalid)\n",
+             invalid[i], get_outcome_name(r.outcome));
+      FAILS += 1;
+    }
+  }
+
+  // stop at first non-number, ptr should point to it
+  {
+    const char *input = "123}";
+    ffc_json_number nr = {0};
+    ffc_result r = ffc_parse_json_number(input, input + strlen(input), &nr);
+    if (r.outcome != FFC_OUTCOME_OK || nr.kind != FFC_JSON_NUM_KIND_INT64
+        || nr.value.i64 != 123 || r.ptr != input + 3) {
+      printf("\nFAIL json_number_unified \"123}\": outcome=%s kind=%d i64=%lld ptr_off=%ld\n",
+             get_outcome_name(r.outcome), (int)nr.kind,
+             (long long)nr.value.i64, (long)(r.ptr - input));
+      FAILS += 1;
+    }
+  }
+}
+
 int main(void) {
   // verify_float("1.1754942807573642917e-38", 0x1.fffffcp-127f);
   // exit(0);
@@ -574,6 +717,7 @@ int main(void) {
   double_parse_zero();
   double_parse_negative_zero();
   double_json_mode();
+  json_number_unified();
 
   float_special();
 


### PR DESCRIPTION
This is an API call to parse json numbers. It returns an int64 if the number isn't a fraction or has exponents (e/E).

```c
typedef uint32_t ffc_json_number_kind;
enum ffc_json_number_kind_bits {
  FFC_JSON_NUM_KIND_INT64  = 0,
  FFC_JSON_NUM_KIND_DOUBLE = 1,
};

typedef struct ffc_json_number {
  ffc_json_number_kind kind;
  union {
    int64_t i64;
    double  f64;
  } value;
} ffc_json_number;

ffc_result ffc_parse_json_number(const char *start, const char *end, ffc_json_number *out);
```

This implements the idea from issue https://github.com/kolemannix/ffc.h/issues/21